### PR TITLE
multi-ip address in module 0.1.3

### DIFF
--- a/bigip.tf
+++ b/bigip.tf
@@ -24,9 +24,8 @@ resource "aws_secretsmanager_secret_version" "bigip-pwd" {
 # Create the BIG-IP appliances
 #
 module "bigip" {
-  # source  = "f5devcentral/bigip/aws"
-  # version = "0.1.2"
-  source = "github.com/f5devcentral/terraform-aws-bigip?ref=multiple-public-ips"
+  source  = "f5devcentral/bigip/aws"
+  version = "0.1.3"
 
   prefix = format(
     "%s-bigip-3-nic_with_new_vpc-%s",


### PR DESCRIPTION
release 0.1.3 of the Terraform registry module has the multiple ip address support required by this demo setup