### PR TITLE
Adjust for module 0.1.3

### DIFF
--- a/bigip.tf
+++ b/bigip.tf
@@ -33,6 +33,7 @@ module "bigip" {
     random_id.id.hex
   )
   aws_secretmanager_secret_id     = aws_secretsmanager_secret.bigip.id
+  application_endpoint_count      = 3
   f5_ami_search_name              = "F5 BIGIP-15.* PAYG-Best 200Mbps*"
   f5_instance_count               = length(var.azs)
   ec2_key_name                    = var.ec2_key_name


### PR DESCRIPTION
makes the necessary adjustments to accommodate release 0.1.3 of the terraform registry aws bigip module. it also fixes deprecation warnings arising from the latest 0.12.x release