### PR TITLE
change source and test to 0.1.4

### DIFF
--- a/bigip.tf
+++ b/bigip.tf
@@ -25,20 +25,21 @@ resource "aws_secretsmanager_secret_version" "bigip-pwd" {
 #
 module "bigip" {
   source  = "f5devcentral/bigip/aws"
-  version = "0.1.3"
+  version = "0.1.4"
 
   prefix = format(
     "%s-bigip-3-nic_with_new_vpc-%s",
     var.prefix,
     random_id.id.hex
   )
-  aws_secretmanager_secret_id     = aws_secretsmanager_secret.bigip.id
-  application_endpoint_count      = 3
-  f5_ami_search_name              = "F5 BIGIP-15.* PAYG-Best 200Mbps*"
-  f5_instance_count               = length(var.azs)
-  ec2_key_name                    = var.ec2_key_name
-  ec2_instance_type               = var.ec2_bigip_type
-  DO_URL                          = "https://github.com/F5Networks/f5-declarative-onboarding/releases/download/v1.8.0/f5-declarative-onboarding-1.8.0-2.noarch.rpm"
+  aws_secretmanager_secret_id = aws_secretsmanager_secret.bigip.id
+  application_endpoint_count  = 3
+  f5_ami_search_name          = "F5 BIGIP-15.* PAYG-Best 200Mbps*"
+  f5_instance_count           = length(var.azs)
+  ec2_key_name                = var.ec2_key_name
+  ec2_instance_type           = var.ec2_bigip_type
+  DO_URL                      = "https://github.com/F5Networks/f5-declarative-onboarding/releases/download/v1.8.0/f5-declarative-onboarding-1.8.0-2.noarch.rpm"
+  AS3_URL                     = "https://github.com/F5Networks/f5-appsvcs-extension/releases/download/v3.16.0/f5-appsvcs-3.16.0-6.noarch.rpm"
 
   mgmt_subnet_security_group_ids  = [
     module.bigip_sg.this_security_group_id,

--- a/inspec/bigip-ready/controls/example.rb
+++ b/inspec/bigip-ready/controls/example.rb
@@ -74,8 +74,8 @@ control "Application Services Available" do
               params: {format: 'html'},
               method: 'GET',
               ssl_verify: false).body) do
-          its('version') { should eq '3.14.0' }
-          its('release') { should eq '4' } # this should be replaced with a test using the json resource
+          its('version') { should eq '3.16.0' }
+          its('release') { should eq '6' } # this should be replaced with a test using the json resource
     end
   end
 end 
@@ -99,7 +99,7 @@ control "Telemetry Streaming Available" do
               params: {format: 'html'},
               method: 'GET',
               ssl_verify: false).body) do
-          its('version') { should eq '1.6.0' }
+          its('version') { should eq '1.8.0' }
           its('release') { should eq '1' } # this should be replaced with a test using the json resource
     end
   end


### PR DESCRIPTION
Referencing the new Terraform Registry module v0.1.4 in order to include telemetry streaming in the automated build. An additional test was performed with the ansible-uber-demo, removing AS3, DO, and TS installation tasks which ran successfully and a little faster.

Results of Inspec test included below (TL;DR -> 100% passed)
------------
Profile: InSpec Profile (bigip-ready)
Version: 0.1.0
Target:  local://

  ✔  Connectivity: BIGIP is reachable
     ✔  Host 44.231.69.162 port 443 proto tcp should be reachable
     ✔  Host 44.228.219.45 port 443 proto tcp should be reachable
  ✔  Declarative Onboarding Available: BIGIP has DO
     ✔  HTTP GET on https://44.231.69.162:443/mgmt/shared/declarative-onboarding/info status should cmp == 200
     ✔  HTTP GET on https://44.231.69.162:443/mgmt/shared/declarative-onboarding/info headers.Content-Type should match "application/json"
     ✔  JSON content [0, "version"] should eq "1.8.0"
     ✔  JSON content [0, "release"] should eq "2"
     ✔  HTTP GET on https://44.228.219.45:443/mgmt/shared/declarative-onboarding/info status should cmp == 200
     ✔  HTTP GET on https://44.228.219.45:443/mgmt/shared/declarative-onboarding/info headers.Content-Type should match "application/json"
     ✔  JSON content [0, "version"] should eq "1.8.0"
     ✔  JSON content [0, "release"] should eq "2"
  ✔  Application Services Available: BIGIP has AS3
     ✔  HTTP GET on https://44.231.69.162:443/mgmt/shared/appsvcs/info status should cmp == 200
     ✔  HTTP GET on https://44.231.69.162:443/mgmt/shared/appsvcs/info headers.Content-Type should match "application/json"
     ✔  JSON content version should eq "3.16.0"
     ✔  JSON content release should eq "6"
     ✔  HTTP GET on https://44.228.219.45:443/mgmt/shared/appsvcs/info status should cmp == 200
     ✔  HTTP GET on https://44.228.219.45:443/mgmt/shared/appsvcs/info headers.Content-Type should match "application/json"
     ✔  JSON content version should eq "3.16.0"
     ✔  JSON content release should eq "6"
  ✔  Telemetry Streaming Available: BIGIP has TS
     ✔  HTTP GET on https://44.231.69.162:443/mgmt/shared/telemetry/info status should cmp == 200
     ✔  HTTP GET on https://44.231.69.162:443/mgmt/shared/telemetry/info headers.Content-Type should match "application/json"
     ✔  JSON content version should eq "1.8.0"
     ✔  JSON content release should eq "1"
     ✔  HTTP GET on https://44.228.219.45:443/mgmt/shared/telemetry/info status should cmp == 200
     ✔  HTTP GET on https://44.228.219.45:443/mgmt/shared/telemetry/info headers.Content-Type should match "application/json"
     ✔  JSON content version should eq "1.8.0"
     ✔  JSON content release should eq "1"

Profile Summary: 4 successful controls, 0 control failures, 0 controls skipped
Test Summary: 26 successful, 0 failures, 0 skipped